### PR TITLE
fix(sqlite): enable FTS5 prefix matching for keyword search

### DIFF
--- a/apps/kbcli/internal/adapters/storages/sqlite.go
+++ b/apps/kbcli/internal/adapters/storages/sqlite.go
@@ -497,7 +497,7 @@ func buildSQLFilters(filters kbs.KBQueryFilter, countSQL, querySQL string) *filt
 	}
 
 	if filters.Keyword != "" {
-		newFilterBuilder.addCondition(tagValuesVirtualColumn, matchOperator, filters.Keyword)
+		newFilterBuilder.addCondition(tagValuesVirtualColumn, matchOperator, filters.Keyword+"*")
 	}
 
 	if filters.Key != "" {

--- a/apps/kbcli/internal/adapters/storages/sqlite_test.go
+++ b/apps/kbcli/internal/adapters/storages/sqlite_test.go
@@ -506,6 +506,34 @@ func TestCreateSQLiteConnection(t *testing.T) {
 	db.Close()
 }
 
+func TestSearchByKeywordPrefix(t *testing.T) {
+	storage := newTestDB(t)
+	ctx := context.Background()
+
+	kb := kbs.KB{
+		ID:        "test-uuid-bubbletea-0001",
+		Key:       "bubbletea-intro",
+		Value:     "Bubbletea is a Go framework for terminal UIs",
+		Notes:     "Used for building TUI applications",
+		Category:  "go",
+		Namespace: "frameworks",
+		Tags:      []string{"bubbletea", "cli", "gui"},
+	}
+	_, err := storage.Create(ctx, kb)
+	require.NoError(t, err)
+
+	// Search with partial keyword "bubble" — should match "bubbletea"
+	filter := kbs.KBQueryFilter{Keyword: "bubble", Limit: 10}
+
+	result, err := storage.Search(ctx, filter)
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.Equal(t, 1, result.Total)
+	assert.Len(t, result.Items, 1)
+	assert.Equal(t, kb.Key, result.Items[0].Key)
+}
+
 func TestCountByCategoryMultiple(t *testing.T) {
 	storage := newTestDB(t)
 	ctx := context.Background()


### PR DESCRIPTION
## Summary
- Append `*` to `filters.Keyword` in `buildSQLFilters` so FTS5 MATCH uses prefix matching instead of exact token equality.
- Add `TestSearchByKeywordPrefix` that inserts a KB with tags "bubbletea cli gui" and asserts searching "bubble" returns the record.

## Test plan
- [x] Unit tests pass (`make test`)
- [x] Lint clean (`make lint`)
- [x] Coverage >= 50% (`make coverage`) — storages package: 81.4%

Resolves #59

Generated with [Claude Code](https://claude.com/claude-code)